### PR TITLE
Fix two minor style issues

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -11,7 +11,7 @@ interface Props {
 const { small } = Astro.props;
 ---
 {small && (
-<footer class="w-[100vw] h-7 bg-page-background text-secondary-foreground z-999 text-xs tracking-wider hidden md:block">
+<footer class="h-7 bg-page-background text-secondary-foreground z-999 text-xs tracking-wider hidden md:block">
     <div class={`flex items-center justify-center ${small ? "mt-2" : "my-5"}`}>
         <a href="/docs/en" target="_blank" class="hover:text-active-foreground transition-colors">Documentation</a>
         <span class="px-2">·</span>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,7 +35,7 @@ import '../components/styles.css';
             <!-- Right Panel with fixed width -->
             <div
                 id="right-panel"
-                class="hidden md:flex min-w-max items-start h-[calc(100svh-5.5rem)] md:h-[calc(100vh-6.2rem)]"
+                class="hidden md:flex min-w-max items-start h-[calc(100svh-5.5rem)] md:h-[calc(100vh-6.2rem)] overflow-x-hidden"
             >
                 <Assembled client:idle />
             </div>


### PR DESCRIPTION
Currently the page shows the horizontal scroll bar by default when opened, this overflow is caused by the width of the footer, the first commit fixes this issue.

<img width="1678" alt="Screenshot 2024-12-20 at 00 12 56" src="https://github.com/user-attachments/assets/ce241acd-08de-4372-9e8e-86c16cf3c45a" />

The horizontal scroll bar of the page also gets visible if the machine code representation on the right panel has a long code line in it. The second commit fixes that issue.

<img width="1680" alt="Screenshot 2024-12-20 at 00 14 56" src="https://github.com/user-attachments/assets/5c08fd59-8b80-46b7-a953-f8489d61e3ab" />
